### PR TITLE
Fix OAuth capitalisation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-Goodreads oAuth API sample
+Goodreads OAuth API sample
 ==============================
 
 
 Description
 ---------------
-A simple command line example of how to use the [Goodreads oAuth API](https://www.goodreads.com/api/)
-from Java using the [Google oAuth Java package](https://code.google.com/p/google-oauth-java-client/).
+A simple command line example of how to use the [Goodreads OAuth API](https://www.goodreads.com/api/)
+from Java using the [Google OAuth Java package](https://code.google.com/p/google-oauth-java-client/).
 
 How to run
 ---------------
@@ -22,9 +22,9 @@ http://stackoverflow.com/questions/15194182/examples-for-oauth1-using-google-api
 
 Details
 ---------------
-The main difference from the example in the post above is that the Goodreads oAuth API doesn't
+The main difference from the example in the post above is that the Goodreads OAuth API doesn't
 return an oauth_verifier parameter (also known as "verifier code") after the user authorizes in
-the browser. According to the [oAuth Bible](http://oauthbible.com/#oauth-10a-three-legged):
+the browser. According to the [OAuth Bible](http://oauthbible.com/#oauth-10a-three-legged):
 
 ```
 On Step 6 if the oauth_verifier has not been set, this is a failed OAuth 1.0a 3-Legged
@@ -34,6 +34,6 @@ Rarely seen but they exist.
 
 This can be worked around by doing as described in the code sample in this repo:
 * Not doing anything with verifier code
-* Setting the signer's tokenSharedSecret to the temporary token's shared secret when retrieving the "real" oAuth token
+* Setting the signer's tokenSharedSecret to the temporary token's shared secret when retrieving the "real" OAuth token
 
 

--- a/src/main/java/oauth/GoodreadsOAuthSample.java
+++ b/src/main/java/oauth/GoodreadsOAuthSample.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  *
  * Adapted from user Sqeezer's StackOverflow post at
  * http://stackoverflow.com/questions/15194182/examples-for-oauth1-using-google-api-java-oauth
- * to work with Goodreads' oAuth API.
+ * to work with Goodreads' OAuth API.
  *
  * Get a key / secret by registering at https://www.goodreads.com/api/keys
  * and replace YOUR_KEY_HERE / YOUR_SECRET_HERE in the code below.
@@ -50,7 +50,7 @@ public class GoodreadsOAuthSample {
         String authUrl = accessTempToken.build();
 
         // Redirect to Authenticate URL in order to get Verifier Code
-        System.out.println("Goodreads oAuth sample: Please visit the following URL to authorize:");
+        System.out.println("Goodreads OAuth sample: Please visit the following URL to authorize:");
         System.out.println(authUrl);
         System.out.println("Waiting 10s to allow time for visiting auth URL and authorizing...");
         Thread.sleep(10000);


### PR DESCRIPTION
## Summary
- update capitalization in README
- update OAuth comment and console output

## Testing
- `mvn -q test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68449291a650832b98f08c4e59d9e0bb